### PR TITLE
ensure quote mask id exists

### DIFF
--- a/CustomerData/SideBySide.php
+++ b/CustomerData/SideBySide.php
@@ -82,8 +82,8 @@ class SideBySide implements SectionSourceInterface
      * @param CurrentCustomer $currentCustomer
      * @param GuestCartResolver $guestCartResolver
      * @param CreateEmptyCartForCustomer $createEmptyCartForCustomer
-     * @param UserTokenParametersFactory|null $tokenParamsFactory
-     * @param UserTokenIssuerInterface|null $tokenIssuer
+     * @param UserTokenParametersFactory $tokenParamsFactory
+     * @param UserTokenIssuerInterface $tokenIssuer
      */
     public function __construct(
         QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId,
@@ -94,8 +94,8 @@ class SideBySide implements SectionSourceInterface
         CreateEmptyCartForCustomer $createEmptyCartForCustomer,
         ?UserTokenParametersFactory $tokenParamsFactory = null,
         ?UserTokenIssuerInterface $tokenIssuer = null,
-        QuoteIdMaskFactory $quoteIdMaskFactory = null,
-        QuoteIdMaskResourceModel $quoteIdMaskResourceModel = null,
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        QuoteIdMaskResourceModel $quoteIdMaskResourceModel,
     ) {
         $this->quoteIdToMaskedQuoteId = $quoteIdToMaskedQuoteId;
         $this->session = $session;


### PR DESCRIPTION
Fixes an issue where the cart_id is returned as an empty string.

This occurs if the quote exists, but there is no corresponding quote mask id.

The logic is taken from https://github.com/magento/magento2/blob/1bafc5712abd635395f0bcfe24ea3f198c18f615/app/code/Magento/Quote/Model/Cart/CustomerCartResolver.php#L97