### PR TITLE
Move Optional Parameters

### DIFF
--- a/CustomerData/SideBySide.php
+++ b/CustomerData/SideBySide.php
@@ -82,8 +82,8 @@ class SideBySide implements SectionSourceInterface
      * @param CurrentCustomer $currentCustomer
      * @param GuestCartResolver $guestCartResolver
      * @param CreateEmptyCartForCustomer $createEmptyCartForCustomer
-     * @param UserTokenParametersFactory|null $tokenParamsFactory
-     * @param UserTokenIssuerInterface|null $tokenIssuer
+     * @param UserTokenParametersFactory $tokenParamsFactory
+     * @param UserTokenIssuerInterface $tokenIssuer
      */
     public function __construct(
         QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId,
@@ -94,8 +94,8 @@ class SideBySide implements SectionSourceInterface
         CreateEmptyCartForCustomer $createEmptyCartForCustomer,
         ?UserTokenParametersFactory $tokenParamsFactory = null,
         ?UserTokenIssuerInterface $tokenIssuer = null,
-        QuoteIdMaskFactory $quoteIdMaskFactory = null,
-        QuoteIdMaskResourceModel $quoteIdMaskResourceModel = null,
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        QuoteIdMaskResourceModel $quoteIdMaskResourceModel,
     ) {
         $this->quoteIdToMaskedQuoteId = $quoteIdToMaskedQuoteId;
         $this->session = $session;

--- a/CustomerData/SideBySide.php
+++ b/CustomerData/SideBySide.php
@@ -57,14 +57,6 @@ class SideBySide implements SectionSourceInterface
      */
     private $createEmptyCartForCustomer;
     /**
-     * @var UserTokenParametersFactory
-     */
-    private $tokenParametersFactory;
-    /**
-     * @var UserTokenIssuerInterface
-     */
-    private $tokenIssuer;
-    /**
      * @var QuoteIdMaskFactory
      */
     private $quoteIdMaskFactory;
@@ -72,7 +64,14 @@ class SideBySide implements SectionSourceInterface
      * @var QuoteIdMaskResourceModel
      */
     private $quoteIdMaskResourceModel;
-
+    /**
+     * @var UserTokenParametersFactory
+     */
+    private $tokenParametersFactory;
+    /**
+     * @var UserTokenIssuerInterface
+     */
+    private $tokenIssuer;
 
 
     /**
@@ -92,10 +91,10 @@ class SideBySide implements SectionSourceInterface
         CurrentCustomer $currentCustomer,
         GuestCartResolver $guestCartResolver,
         CreateEmptyCartForCustomer $createEmptyCartForCustomer,
-        ?UserTokenParametersFactory $tokenParamsFactory = null,
-        ?UserTokenIssuerInterface $tokenIssuer = null,
         QuoteIdMaskFactory $quoteIdMaskFactory,
         QuoteIdMaskResourceModel $quoteIdMaskResourceModel,
+        ?UserTokenParametersFactory $tokenParamsFactory = null,
+        ?UserTokenIssuerInterface $tokenIssuer = null,
     ) {
         $this->quoteIdToMaskedQuoteId = $quoteIdToMaskedQuoteId;
         $this->session = $session;


### PR DESCRIPTION
Moved the optional parameters down, since this was causing a deprecation warning on the customer's systems:

```
#21 495.0   Deprecated Functionality: Optional parameter $tokenParamsFactory declared b  
#21 495.0   efore required parameter $quoteIdMaskResourceModel is implicitly treated as  
#21 495.0    a required parameter in /var/www/magento/vendor/atama/module-share/Custome  
#21 495.0   rData/SideBySide.php on line 88  
```